### PR TITLE
Reverting async/await loop changes and hasOwnProperty() check

### DIFF
--- a/src/js/background.js
+++ b/src/js/background.js
@@ -368,9 +368,9 @@ async function createGroupInWindowIfMissing(browserWindow) {
 async function setupWindows() {
   const windows = await browser.windows.getAll({});
 
-  windows.forEach(async (window) => {
-    await createGroupInWindowIfMissing(window);
-  });
+  for(const win of windows) {
+    await createGroupInWindowIfMissing(win);
+  }
 }
 
 /** Put any tabs that do not have a group into the active group */
@@ -379,15 +379,15 @@ async function salvageGrouplessTabs() {
   const windows = {};
   const tWindows = await browser.windows.getAll({});
 
-  tWindows.forEach(async (window) => {
-    windows[window.id] = { groups: null };
-    windows[window.id].groups = await browser.sessions.getWindowValue(window.id, 'groups');
-  });
+  for(const win of tWindows) {
+    windows[win.id] = { groups: null };
+    windows[win.id].groups = await browser.sessions.getWindowValue(win.id, 'groups');
+  }
 
   // check all tabs
   const tabs = await browser.tabs.query({});
 
-  tabs.forEach(async (tab) => {
+  for(const tab of tabs) {
     const groupId = await browser.sessions.getTabValue(tab.id, 'groupId');
 
     let groupExists = false;
@@ -401,7 +401,7 @@ async function salvageGrouplessTabs() {
       const activeGroup = await browser.sessions.getWindowValue(tab.windowId, 'activeGroup');
       await browser.sessions.setTabValue(tab.id, 'groupId', activeGroup);
     }
-  });
+  }
 }
 
 async function init() {

--- a/src/js/options/index.js
+++ b/src/js/options/index.js
@@ -18,7 +18,7 @@ import resetPTG from './reset.js';
 function restoreOptions(options, loadedShortcuts) {
   // Shortcuts
   loadedShortcuts.forEach((shortcut) => {
-    if (Object.prototype.hasOwnProperty.call(shortcut, 'name')) {
+    if (!options.shortcut.hasOwnProperty(shortcut.name)) {
       return;
     }
     if (options.shortcut[shortcut.name].disabled) {
@@ -63,7 +63,7 @@ function attachEventHandler(options, loadedShortcuts) {
       .querySelector('.enableShortcut')
       .addEventListener('click', enableShortcut.bind(this, options));
 
-    if (Object.prototype.hasOwnProperty.call(shortcut, 'name')) {
+    if (options.shortcut.hasOwnProperty(shortcut.name)) {
       shortcutNode
         .querySelector('.disableShortcut')
         .addEventListener('click', disableShortcut.bind(this, options));

--- a/src/js/options/statistics.js
+++ b/src/js/options/statistics.js
@@ -6,7 +6,7 @@ export default async function getStatistics() {
   let totalSize = 0;
   let numActiveTabs = 0;
 
-  tabs.forEach(async (tab) => {
+  for(const tab of tabs) {
     const thumbnail = await browser.sessions.getTabValue(tab.id, 'thumbnail');
 
     if (thumbnail) {
@@ -19,7 +19,7 @@ export default async function getStatistics() {
     if (!tab.discarded) {
       numActiveTabs += 1;
     }
-  });
+  }
   console.log(numActiveTabs);
 
   document.getElementById('thumbnailCacheSize').innerHTML = '';

--- a/src/js/view/tabs.js
+++ b/src/js/view/tabs.js
@@ -2,24 +2,24 @@ export async function setGroupId(tabId, groupId) {
   await browser.sessions.setTabValue(tabId, 'groupId', parseInt(groupId, 10));
 }
 
-export async function getGroupId(tabId) {
+export function getGroupId(tabId) {
   return browser.sessions.getTabValue(tabId, 'groupId');
 }
 
-export async function getAllTabsInWindow() {
+export function getAllTabsInWindow() {
   return browser.tabs.query({ currentWindow: true });
 }
 
 export async function forEachTab(callback) {
   const tabs = await getAllTabsInWindow();
-  tabs.forEach(async (tab, tabIndex) => {
-    await callback(tabs[tabIndex]);
-  });
+  for(const tab of tabs) {
+    callback(tab);
+  }
 }
 
 export async function forEachTabSync(callback) {
   const tabs = await getAllTabsInWindow();
-  tabs.forEach((tab) => {
+  for(const tab of tabs) {
     callback(tab);
-  });
+  }
 }


### PR DESCRIPTION
Fixes issues introduced when switching from `for...of` to `Array.forEach()` loops. The former's loop body blocks and awaits in the same execution scope as the containing function, while the latter's loop body doesn't block when the callback function is marked as async (which is necessary for the awaits included in the function). This was resulting in subsequent code running before the loops had finished.

Alternative for an awaitable loop would be to switch it to an `Array.map()`that you then pass directly into a `Promise.all()`:
```js
async function foo() {
    await Promise.all(someArray.map( async (elm) => {
        await stuff()
    }));
}
```
---
For the options, some `Object.hasOwnProperty()` calls seem to have been incorrectly rewritten to check the wrong object. I just reverted those changes, but it could also just be rewritten as:
```js
Object.prototype.hasOwnProperty.call(options.shortcut, shortcut.name)
```